### PR TITLE
Fix error handling

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,30 +1,63 @@
-use std::error;
-use std::fmt;
-use std::result;
+use std::ffi::CStr;
+use std::fmt::Display;
 
-#[derive(Debug)]
-pub struct Error {
-    inner: String,
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Error {
+    Os(i32),
+    Msg(String),
 }
 
-pub type Result<T> = result::Result<T, Error>;
+pub type Result<T> = std::result::Result<T, Error>;
 
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(&self.inner)
+// https://github.com/rust-lang/rust/blob/e649e903440bfd919bfc9db848c28df6d795a116/src/libstd/sys/unix/os.rs#L91
+fn errno_string(errno: i32) -> String {
+    const TMPBUF_SZ: usize = 128;
+    let mut buf = [0 as libc::c_char; TMPBUF_SZ];
+    let c_str = unsafe {
+        if libc::strerror_r(errno, buf.as_mut_ptr(), buf.len()) < 0 {
+            panic!("strerror_r failure")
+        }
+        CStr::from_ptr(buf.as_ptr())
+    };
+    c_str.to_str().unwrap().to_owned()
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            Error::Os(errno) => f.write_str(&errno_string(errno)),
+            Error::Msg(ref msg) => f.write_str(msg),
+        }
     }
 }
 
-impl error::Error for Error {
-    fn description(&self) -> &str {
-        &self.inner
+impl Error {
+    #[inline]
+    pub fn from_errno(errno: i32) -> Self {
+        Error::Os(errno)
+    }
+
+    #[inline]
+    pub fn errno(&self) -> Option<i32> {
+        match *self {
+            Error::Os(errno) => Some(errno),
+            Error::Msg(_) => None,
+        }
     }
 }
 
 impl From<String> for Error {
-    fn from(err: String) -> Error {
-        Error {
-            inner: err.into(),
+    fn from(msg: String) -> Error {
+        Error::Msg(msg)
+    }
+}
+
+impl std::error::Error for Error {
+    /// This method is soft-deprecated.
+    fn description(&self) -> &str {
+        match *self {
+            Error::Os(_) => "seccomp os error; use Display",
+            Error::Msg(ref msg) => msg,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,18 +85,14 @@ impl Context {
             "seccomp: setting action={:?} syscall={:?} comparators={:?}",
             action, syscall, comparators
         );
-        let comps: Vec<scmp_arg_cmp> = comparators
-            .iter()
-            .map(|comp| comp.clone().into())
-            .collect::<_>();
 
         let ret = unsafe {
             seccomp_rule_add_array(
                 self.ctx,
                 action.into(),
                 syscall.into_i32(),
-                comps.len() as u32,
-                comps.as_ptr(),
+                comparators.len() as u32,
+                comparators.as_ptr() as *const scmp_arg_cmp
             )
         };
         if ret != 0 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ impl Context {
     }
 
     /// Initialize a context with default_action.
-    /// 
+    ///
     /// Returns Err(Error::Msg) if seccomp_init returned NULL.
     pub fn init_with_action(default_action: Action) -> Result<Context> {
         let ctx = unsafe { seccomp_init(default_action.into()) };
@@ -80,7 +80,7 @@ impl Context {
     }
 
     /// Returns Err(Error::Os) if seccomp_rule_add_array failed.
-    /// 
+    ///
     /// Due to [seccomp/libseccomp #118](https://github.com/seccomp/libseccomp/issues/118),
     /// this method only allows you to specify one comparison per argument.
     pub fn set_rule_for_syscall(
@@ -110,7 +110,7 @@ impl Context {
     }
 
     /// Loads the seccomp filter into the kernel.
-    /// 
+    ///
     /// Returns Err(Error::Os) if seccomp_load failed.
     pub fn load(&self) -> Result<()> {
         debug!("seccomp: loading policy");
@@ -177,7 +177,7 @@ mod tests {
         ctx.set_rule_for_syscall(
             Action::Errno(1),
             Syscall::read,
-            &[Comparator::new(0, Cmp::Eq, f.as_raw_fd() as u64, None)],
+            &[Comparator::new(0, Cmp::Eq, f.as_raw_fd() as u64, 0)],
         )
         .unwrap();
         ctx.load().unwrap();

--- a/src/rule.rs
+++ b/src/rule.rs
@@ -1,4 +1,4 @@
-use seccomp_sys::*;
+use seccomp_sys::{scmp_arg_cmp, scmp_compare};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, EnumString)]
 pub enum Cmp {
@@ -27,32 +27,23 @@ impl Into<scmp_compare> for Cmp {
     }
 }
 
-#[derive(Debug, Clone)]
-pub struct Comparator {
-    arg: u32,
-    op: Cmp,
-    datum_a: u64,
-    datum_b: u64,
+#[derive(Debug)]
+#[repr(transparent)]
+pub struct Comparator(scmp_arg_cmp);
+
+impl Clone for Comparator {
+    fn clone(&self) -> Self {
+        unsafe { std::ptr::read(self as *const Comparator) }
+    }
 }
 
 impl Comparator {
     pub fn new(arg: u32, op: Cmp, datum_a: u64, datum_b: Option<u64>) -> Self {
-        Self {
+        Self(scmp_arg_cmp {
             arg,
-            op,
+            op: op.into(),
             datum_a,
             datum_b: datum_b.unwrap_or(0_u64),
-        }
-    }
-}
-
-impl Into<scmp_arg_cmp> for Comparator {
-    fn into(self) -> scmp_arg_cmp {
-        scmp_arg_cmp {
-            arg: self.arg,
-            op: self.op.into(),
-            datum_a: self.datum_a,
-            datum_b: self.datum_b,
-        }
+        })
     }
 }

--- a/src/rule.rs
+++ b/src/rule.rs
@@ -1,3 +1,4 @@
+use scmp_compare::*;
 use seccomp_sys::{scmp_arg_cmp, scmp_compare};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, EnumString)]
@@ -11,10 +12,26 @@ pub enum Cmp {
     MaskedEq,
 }
 
+impl Cmp {
+    #[inline]
+    fn force_from(compare: scmp_compare) -> Self {
+        use self::Cmp::*;
+        match compare {
+            SCMP_CMP_NE => Ne,
+            SCMP_CMP_LT => Lt,
+            SCMP_CMP_LE => Le,
+            SCMP_CMP_EQ => Eq,
+            SCMP_CMP_GE => Ge,
+            SCMP_CMP_GT => Gt,
+            SCMP_CMP_MASKED_EQ => MaskedEq,
+            _ => unreachable!(),
+        }
+    }
+}
+
 impl Into<scmp_compare> for Cmp {
     fn into(self) -> scmp_compare {
         use self::Cmp::*;
-        use scmp_compare::*;
         match self {
             Ne => SCMP_CMP_NE,
             Lt => SCMP_CMP_LT,
@@ -38,12 +55,32 @@ impl Clone for Comparator {
 }
 
 impl Comparator {
-    pub fn new(arg: u32, op: Cmp, datum_a: u64, datum_b: Option<u64>) -> Self {
+    pub fn new(arg: u32, op: Cmp, datum_a: u64, datum_b: u64) -> Self {
         Self(scmp_arg_cmp {
             arg,
             op: op.into(),
             datum_a,
-            datum_b: datum_b.unwrap_or(0_u64),
+            datum_b,
         })
+    }
+
+    #[inline]
+    pub fn arg(&self) -> u32 {
+        self.0.arg
+    }
+
+    #[inline]
+    pub fn op(&self) -> Cmp {
+        Cmp::force_from(self.0.op)
+    }
+
+    #[inline]
+    pub fn datum_a(&self) -> u64 {
+        self.0.datum_a
+    }
+
+    #[inline]
+    pub fn datum_b(&self) -> u64 {
+        self.0.datum_b
     }
 }


### PR DESCRIPTION
## Avoid unnecessary copy
Add `repr(transparent)` on `Comparator`. So the slice can be directly converted into  `*const scmp_arg_cmp` and be passed into  `seccomp_rule_add_array`.

## Fix error handling

[seccomp_init(3)](http://www.man7.org/linux/man-pages/man3/seccomp_init.3.html) returns NULL on failure.
[seccomp_load(3)](http://man7.org/linux/man-pages/man3/seccomp_load.3.html) and some ctx operations return negative errno values on failure.

So we should export what the error exactly is.

This may be a break change. (I'm not sure)
```rust
pub enum Error {
    Os(i32),
    Msg(String),
}
```