### PR TITLE
Support the SCMP_ACT_KILL_PROCESS seccomp action.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub use syscalls::Syscall;
 #[derive(Debug, Clone, Copy)]
 pub enum Action {
     Kill,
+    KillThread,
     Trap,
     Errno(u16),
     Trace(u16),
@@ -30,7 +31,8 @@ impl Into<u32> for Action {
     fn into(self) -> u32 {
         use self::Action::*;
         match self {
-            Kill => SCMP_ACT_KILL,
+            Kill => SCMP_ACT_KILL_PROCESS,
+            KillProcess => SCMP_ACT_KILL,
             Trap => SCMP_ACT_TRAP,
             Errno(e) => SCMP_ACT_ERRNO(e.into()),
             Trace(t) => SCMP_ACT_TRACE(t.into()),


### PR DESCRIPTION
**Note** this change depends on polachok/seccomp-sys#9 to build. I verified that the change works locally by overriding my local Cargo.tomls. It also breaks compatibility by changing the meaning of `Action::Kill` to the more intuitive meaning, per discussion in #13. It's easy to change back if we prefer to add `Action::KillProcess` instead.

Before this change, Action::Kill only terminates the calling
_thread_, not the entire process. This is almost always the wrong
thing to do, because programs aren't robust against single threads
going away.

This change makes Action::Kill terminate the whole process, which
is intuitively what most people expect. The single-thread behavior
is still available as Action::KillThread, for corner cases where
it makes sense.